### PR TITLE
Yvm exec

### DIFF
--- a/src/commands/exec.js
+++ b/src/commands/exec.js
@@ -1,0 +1,25 @@
+const fs = require('fs')
+const os = require('os')
+const path = require('path')
+
+const getYarnCLI = version => (
+    path.resolve(getYarnPath(version), 'bin/yarn.js')
+)
+
+const getYarnPath = version => (
+    path.resolve(os.homedir(), `.yvm/versions/v${version}`)
+)
+
+const execCommand = (version, extraArgs) => {
+    const yarnPath = getYarnPath(version)
+    if(!fs.existsSync(yarnPath)) {
+        console.log(`Yarn v${version} not found. Please install it using: yvm install ${version}`)
+        return
+    }
+
+    const yarnCLI = getYarnCLI(version)
+    process.argv = ['',''].concat(extraArgs) //first two arguments are filler args [node version, yarn version]
+    require(yarnCLI)
+}
+
+module.exports = execCommand

--- a/src/commands/exec.js
+++ b/src/commands/exec.js
@@ -1,19 +1,21 @@
+/* eslint-disable global-require,prettier/prettier,import/no-dynamic-require */
 const fs = require('fs')
 const os = require('os')
 const path = require('path')
 
-const getYarnPath = version => (
+const getYarnPath = version =>
     path.resolve(os.homedir(), `.yvm/versions/v${version}`)
-)
 
 const runYarn = (version, extraArgs) => {
-    process.argv = ['',''].concat(extraArgs) //first two arguments are filler args [node version, yarn version]
+    process.argv = ['', ''].concat(extraArgs) // first two arguments are filler args [node version, yarn version]
     require(path.resolve(getYarnPath(version), 'bin/yarn.js'))
 }
 
 const execCommand = (version, extraArgs) => {
-    if(!fs.existsSync(getYarnPath(version))) {
-        console.log(`Yarn v${version} not found. Please install it using: yvm install ${version}`)
+    if (!fs.existsSync(getYarnPath(version))) {
+        console.log(
+            `Yarn v${version} not found. Please install it using: yvm install ${version}`,
+        )
         return
     }
     runYarn(version, extraArgs)

--- a/src/commands/exec.js
+++ b/src/commands/exec.js
@@ -1,4 +1,4 @@
-/* eslint-disable global-require,prettier/prettier,import/no-dynamic-require */
+/* eslint-disable global-require,import/no-dynamic-require */
 const fs = require('fs')
 const os = require('os')
 const path = require('path')

--- a/src/commands/exec.js
+++ b/src/commands/exec.js
@@ -2,24 +2,21 @@ const fs = require('fs')
 const os = require('os')
 const path = require('path')
 
-const getYarnCLI = version => (
-    path.resolve(getYarnPath(version), 'bin/yarn.js')
-)
-
 const getYarnPath = version => (
     path.resolve(os.homedir(), `.yvm/versions/v${version}`)
 )
 
+const runYarn = (version, extraArgs) => {
+    process.argv = ['',''].concat(extraArgs) //first two arguments are filler args [node version, yarn version]
+    require(path.resolve(getYarnPath(version), 'bin/yarn.js'))
+}
+
 const execCommand = (version, extraArgs) => {
-    const yarnPath = getYarnPath(version)
-    if(!fs.existsSync(yarnPath)) {
+    if(!fs.existsSync(getYarnPath(version))) {
         console.log(`Yarn v${version} not found. Please install it using: yvm install ${version}`)
         return
     }
-
-    const yarnCLI = getYarnCLI(version)
-    process.argv = ['',''].concat(extraArgs) //first two arguments are filler args [node version, yarn version]
-    require(yarnCLI)
+    runYarn(version, extraArgs)
 }
 
 module.exports = execCommand

--- a/src/index.js
+++ b/src/index.js
@@ -16,9 +16,14 @@ module.exports = function(args) {
         })
 
     argParser
-        .command('manage <version>')
-        .action(version => {
-            console.log(`Managing yarn v${version}`)
+        .command('exec <version>')
+        .action((version) => {
+            console.log(`Executing yarn command with version ${version}`)
+            const exec = require('./commands/exec')
+            console.log(args)
+            const extraArgs = args.slice(4)  //returns args without [npm, start, exec, <version>, <command>]
+            console.log(extraArgs)
+            exec(version, extraArgs)
         })
 
     argParser.parse(args)

--- a/src/index.js
+++ b/src/index.js
@@ -17,11 +17,10 @@ module.exports = function dispatch(args) {
         })
 
     argParser
-        .command('exec <version>')
-        .action((version) => {
+        .command('exec <version> [extraArgs...]')
+        .action((version, extraArgs) => {
             console.log(`Executing yarn command with version ${version}`)
             const exec = require('./commands/exec')
-            const extraArgs = args.slice(4)  //returns args without [npm, start, exec, <version>, <command>]
             exec(version, extraArgs)
         })
 

--- a/src/index.js
+++ b/src/index.js
@@ -20,9 +20,7 @@ module.exports = function(args) {
         .action((version) => {
             console.log(`Executing yarn command with version ${version}`)
             const exec = require('./commands/exec')
-            console.log(args)
             const extraArgs = args.slice(4)  //returns args without [npm, start, exec, <version>, <command>]
-            console.log(extraArgs)
             exec(version, extraArgs)
         })
 


### PR DESCRIPTION
- implemented yvm exec command
- usage: `yvm exec <version> <yarn commands>`

## Dev prep
- use yvm install to get 1.7.0 and 1.0.2

## QA Steps
- `make install` and open a new terminal (or `source /usr/local/bin/yvm`)
- use `yvm exec 1.7.0 versions`
- use `yvm exec 1.0.2 versions`
- ensure the correct output from both
- navigate to fe-thm, use `yvm exec 1.0.2 upgrade-interactive` and ensure it works as expected