### PR TITLE
Auto-install and use stderr

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,7 +5,6 @@
     "prettier"
   ],
   "rules": {
-    "no-console": 0,
     "prettier/prettier": [
       2,
       {

--- a/src/commands/exec.js
+++ b/src/commands/exec.js
@@ -13,12 +13,11 @@ const runYarn = (version, extraArgs) => {
 
 const execCommand = (version, extraArgs) => {
     if (!fs.existsSync(getYarnPath(version))) {
-        console.log(
-            `Yarn v${version} not found. Please install it using: yvm install ${version}`,
-        )
-        return
+        const install = require('./install')
+        install(version).then(() => runYarn(version, extraArgs))
+    } else {
+        runYarn(version, extraArgs)
     }
-    runYarn(version, extraArgs)
 }
 
 module.exports = execCommand

--- a/src/commands/install.js
+++ b/src/commands/install.js
@@ -3,6 +3,7 @@ const path = require('path')
 const request = require('request')
 const targz = require('targz')
 
+const log = require('../common/log')
 const { versionRootPath, getExtractionPath } = require('../common/utils')
 
 const directoryStack = []
@@ -58,10 +59,10 @@ const extractYarn = version => {
             },
             err => {
                 if (err) {
-                    console.error(err)
+                    log(err)
                     reject(err)
                 } else {
-                    console.error(`Finished extracting yarn version ${version}`)
+                    log(`Finished extracting yarn version ${version}`)
                     fs.renameSync(
                         `${destPath}/yarn-v${version}`,
                         `${destPath}/v${version}`,
@@ -80,11 +81,11 @@ const installVersion = version => {
     }
     return downloadVersion(version)
         .then(() => {
-            console.error(`Finished downloading yarn version ${version}`)
+            log(`Finished downloading yarn version ${version}`)
             return extractYarn(version)
         })
         .catch(err => {
-            console.error(`Downloading yarn failed: \n ${err}`)
+            log(`Downloading yarn failed: \n ${err}`)
             cleanDirectories()
         })
 }

--- a/src/commands/install.js
+++ b/src/commands/install.js
@@ -49,37 +49,42 @@ const downloadVersion = version => {
 const extractYarn = version => {
     const destPath = versionRootPath
     const srcPath = getDownloadPath(version)
-    targz.decompress(
-        {
-            src: srcPath,
-            dest: destPath,
-        },
-        err => {
-            if (err) {
-                console.log(err)
-            } else {
-                console.log(`Finished extracting yarn version ${version}`)
-                fs.renameSync(
-                    `${destPath}/yarn-v${version}`,
-                    `${destPath}/v${version}`,
-                )
-                fs.unlinkSync(srcPath)
-            }
-        },
-    )
+
+    return new Promise((resolve, reject) => {
+        targz.decompress(
+            {
+                src: srcPath,
+                dest: destPath,
+            },
+            err => {
+                if (err) {
+                    console.error(err)
+                    reject(err)
+                } else {
+                    console.error(`Finished extracting yarn version ${version}`)
+                    fs.renameSync(
+                        `${destPath}/yarn-v${version}`,
+                        `${destPath}/v${version}`,
+                    )
+                    fs.unlinkSync(srcPath)
+                    resolve()
+                }
+            },
+        )
+    })
 }
 
 const installVersion = version => {
     if (checkForVersion(version)) {
-        return
+        return Promise.resolve()
     }
-    downloadVersion(version)
+    return downloadVersion(version)
         .then(() => {
-            console.log(`Finished downloading yarn version ${version}`)
-            extractYarn(version)
+            console.error(`Finished downloading yarn version ${version}`)
+            return extractYarn(version)
         })
         .catch(err => {
-            console.log(`Downloading yarn failed: \n ${err}`)
+            console.error(`Downloading yarn failed: \n ${err}`)
             cleanDirectories()
         })
 }

--- a/src/commands/list.js
+++ b/src/commands/list.js
@@ -1,5 +1,6 @@
 const fs = require('fs')
 
+const log = require('../common/log')
 const { printVersions, versionRootPath } = require('../common/utils')
 
 const getYarnVersions = () => {
@@ -15,7 +16,7 @@ const listVersions = () => {
     if (installedVersions.length) {
         printVersions(installedVersions, 'Installed yarn versions:')
     } else {
-        console.error('You have no yarn versions installed.')
+        log('You have no yarn versions installed.')
     }
 }
 

--- a/src/commands/list.js
+++ b/src/commands/list.js
@@ -15,7 +15,7 @@ const listVersions = () => {
     if (installedVersions.length) {
         printVersions(installedVersions, 'Installed yarn versions:')
     } else {
-        console.log('You have no yarn versions installed.')
+        console.error('You have no yarn versions installed.')
     }
 }
 

--- a/src/commands/remove.js
+++ b/src/commands/remove.js
@@ -5,7 +5,7 @@ const { getExtractionPath } = require('../common/utils')
 const removeVersion = version => {
     const versionPath = getExtractionPath(version)
     if (!fs.existsSync(versionPath)) {
-        console.log(
+        console.error(
             `Failed to remove yarn v${version}. Yarn version ${version} not found.`,
         )
         return
@@ -13,9 +13,9 @@ const removeVersion = version => {
 
     try {
         fs.removeSync(versionPath)
-        console.log(`Successfully removed yarn v${version}.`)
+        console.error(`Successfully removed yarn v${version}.`)
     } catch (err) {
-        console.log(`Failed to remove yarn v${version}. \n ${err}`)
+        console.error(`Failed to remove yarn v${version}. \n ${err}`)
     }
 }
 

--- a/src/commands/remove.js
+++ b/src/commands/remove.js
@@ -1,11 +1,12 @@
 const fs = require('fs-extra')
 
 const { getExtractionPath } = require('../common/utils')
+const log = require('../common/log')
 
 const removeVersion = version => {
     const versionPath = getExtractionPath(version)
     if (!fs.existsSync(versionPath)) {
-        console.error(
+        log(
             `Failed to remove yarn v${version}. Yarn version ${version} not found.`,
         )
         return
@@ -13,9 +14,9 @@ const removeVersion = version => {
 
     try {
         fs.removeSync(versionPath)
-        console.error(`Successfully removed yarn v${version}.`)
+        log(`Successfully removed yarn v${version}.`)
     } catch (err) {
-        console.error(`Failed to remove yarn v${version}. \n ${err}`)
+        log(`Failed to remove yarn v${version}. \n ${err}`)
     }
 }
 

--- a/src/common/log.js
+++ b/src/common/log.js
@@ -1,0 +1,12 @@
+const defaultLogger = console.error.bind(console) // eslint-disable-line no-console
+const capturableLogger = console.log.bind(console) // eslint-disable-line no-console
+
+function log(...args) {
+    defaultLogger(...args)
+}
+
+log.capturable = function capturableLog(...args) {
+    capturableLogger(...args)
+}
+
+module.exports = log

--- a/src/common/utils.js
+++ b/src/common/utils.js
@@ -1,6 +1,8 @@
 const os = require('os')
 const path = require('path')
 
+const log = require('../common/log')
+
 const yvmPath = path.resolve(os.homedir(), '.yvm')
 const versionRootPath = path.resolve(yvmPath, 'versions')
 
@@ -8,9 +10,9 @@ const getExtractionPath = version =>
     path.resolve(versionRootPath, `v${version}`)
 
 const printVersions = (list, message) => {
-    console.error(message)
+    log(message)
     list.forEach(item => {
-        console.error(`  - ${item}`)
+        log(`  - ${item}`)
     })
 }
 

--- a/src/common/utils.js
+++ b/src/common/utils.js
@@ -8,9 +8,9 @@ const getExtractionPath = version =>
     path.resolve(versionRootPath, `v${version}`)
 
 const printVersions = (list, message) => {
-    console.log(message)
+    console.error(message)
     list.forEach(item => {
-        console.log(`  - ${item}`)
+        console.error(`  - ${item}`)
     })
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ const { getRcFileVersion, isValidVersionString } = require('./util/version')
 const withRcFileVersion = action => (maybeVersionArg, ...rest) => {
     if (maybeVersionArg) {
         if (isValidVersionString(maybeVersionArg)) {
-            console.log(`Using provided version: ${maybeVersionArg}`)
+            console.error(`Using provided version: ${maybeVersionArg}`)
             action(maybeVersionArg, ...rest)
             return
         }
@@ -14,10 +14,10 @@ const withRcFileVersion = action => (maybeVersionArg, ...rest) => {
 
     const version = getRcFileVersion()
     if (isValidVersionString(version)) {
-        console.log(`Using .yvmrc version: ${version}`)
+        console.error(`Using .yvmrc version: ${version}`)
         action(version, ...rest)
     } else {
-        console.warn(`Invalid .yvmrc version: ${version}`)
+        console.error(`Invalid .yvmrc version: ${version}`)
         process.exit(1)
     }
 }
@@ -43,7 +43,7 @@ module.exports = function dispatch(args) {
     argParser
         .command('exec [version] [extraArgs...]')
         .action(withRcFileVersion((version, extraArgs) => {
-            console.log(`Executing yarn command with version ${version}`)
+            console.error(`Executing yarn command with version ${version}`)
             const exec = require('./commands/exec')
             exec(version, extraArgs)
         }))

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,12 @@
 const argParser = require('commander')
 
 const { getRcFileVersion, isValidVersionString } = require('./util/version')
+const log = require('./common/log')
 
 const withRcFileVersion = action => (maybeVersionArg, ...rest) => {
     if (maybeVersionArg) {
         if (isValidVersionString(maybeVersionArg)) {
-            console.error(`Using provided version: ${maybeVersionArg}`)
+            log(`Using provided version: ${maybeVersionArg}`)
             action(maybeVersionArg, ...rest)
             return
         }
@@ -14,10 +15,10 @@ const withRcFileVersion = action => (maybeVersionArg, ...rest) => {
 
     const version = getRcFileVersion()
     if (isValidVersionString(version)) {
-        console.error(`Using .yvmrc version: ${version}`)
+        log(`Using .yvmrc version: ${version}`)
         action(version, ...rest)
     } else {
-        console.error(`Invalid .yvmrc version: ${version}`)
+        log(`Invalid .yvmrc version: ${version}`)
         process.exit(1)
     }
 }
@@ -27,7 +28,7 @@ module.exports = function dispatch(args) {
     argParser
         .command('install [version]')
         .action(withRcFileVersion(version => {
-            console.error(`Installing yarn v${version}`)
+            log(`Installing yarn v${version}`)
             const install = require('./commands/install')
             install(version)
         }))
@@ -35,7 +36,7 @@ module.exports = function dispatch(args) {
     argParser
         .command('remove <version>')
         .action(version => {
-            console.error(`Removing yarn v${version}`)
+            log(`Removing yarn v${version}`)
             const remove = require('./commands/remove')
             remove(version)
         })
@@ -43,7 +44,7 @@ module.exports = function dispatch(args) {
     argParser
         .command('exec [version] [extraArgs...]')
         .action(withRcFileVersion((version, extraArgs) => {
-            console.error(`Executing yarn command with version ${version}`)
+            log(`Executing yarn command with version ${version}`)
             const exec = require('./commands/exec')
             exec(version, extraArgs)
         }))
@@ -51,7 +52,7 @@ module.exports = function dispatch(args) {
     argParser
         .command('list')
         .action(() => {
-            console.error(`Checking for installed yarn versions...`)
+            log(`Checking for installed yarn versions...`)
             const listVersions = require('./commands/list')
             listVersions()
         })

--- a/src/index.js
+++ b/src/index.js
@@ -27,7 +27,7 @@ module.exports = function dispatch(args) {
     argParser
         .command('install [version]')
         .action(withRcFileVersion(version => {
-            console.log(`Installing yarn v${version}`)
+            console.error(`Installing yarn v${version}`)
             const install = require('./commands/install')
             install(version)
         }))
@@ -35,7 +35,7 @@ module.exports = function dispatch(args) {
     argParser
         .command('remove <version>')
         .action(version => {
-            console.log(`Removing yarn v${version}`)
+            console.error(`Removing yarn v${version}`)
             const remove = require('./commands/remove')
             remove(version)
         })
@@ -51,7 +51,7 @@ module.exports = function dispatch(args) {
     argParser
         .command('list')
         .action(() => {
-            console.log(`Checking for installed yarn versions...`)
+            console.error(`Checking for installed yarn versions...`)
             const listVersions = require('./commands/list')
             listVersions()
         })


### PR DESCRIPTION
## Description
- Auto install for ease
- Use stderr to avoid polluting `yarn` output

## DevQA

### DevQA Steps
- `make install`
- `yvm exec 1.7.0 versions` should install 1.7.0, then output the result of the command
- Running it again should use the installed version
- `yvm exec bin 2> /dev/null` should not print anything that `yarn` itself doesn't print