### PR TITLE
Show help on invalid command

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -28,6 +28,14 @@ argParser
     .description('Yarn Version Manager')
 
 argParser
+    .command('*', '', {noHelp: true, isDefault: true})
+    .action(invalidCommand => {
+        log(`Invalid command: ${invalidCommand}`)
+        argParser.outputHelp()
+        process.exit(1)
+    })
+
+argParser
     .command('install [version]')
     .alias('i')
     .description('Install the specified version of Yarn.')
@@ -77,7 +85,7 @@ argParser
 
 const noParams = !process.argv.slice(2).length
 if (noParams) {
-    argParser.outputHelp();
+    argParser.outputHelp()
 }
 
 /* eslint-enable global-require,prettier/prettier */


### PR DESCRIPTION
## Description
<!-- Add a bulleted list of items changed or added -->

Addresses #54 

- Add wildcard command that gets executed if no other command is matched
- Show warning and output help

## DevQA

### DevQA Prep
<!-- Delete items that do not apply. -->
- Run `make install`

### DevQA Steps
<!-- Fill in steps to DevQA this PR here -->

- Try running yvm with an invalid command
- Verify that it tells you that the command is invalid
- Verify that it prints out help string
