### PR TITLE
Better interactive shell detection

### DIFF
--- a/src/yvm.sh
+++ b/src/yvm.sh
@@ -87,10 +87,9 @@ yvm_() {
     fi
 }
 
-if [ -n "$PS1" ]; then
-    yvm() {
-        yvm_ $@
-    }
-else
-    yvm_ $@
-fi
+case "$-" in
+    *i*)    yvm() {
+                yvm_ $@
+            };;
+    *)	    yvm_ $@;;
+esac


### PR DESCRIPTION
According to https://www.gnu.org/software/bash/manual/html_node/Is-this-Shell-Interactive_003f.html, the old and new methods should be equivalent, but on CircleCI, $PS1 is set even in non-interactive shells
