### PR TITLE
Source yvm in .bash_profile during install

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -55,4 +55,9 @@ if ! grep -q "${executable_source_string}" ~/.zshrc; then
     echo ${executable_source_string} >> ~/.zshrc
 fi
 
+if ! grep -q "${executable_source_string}" ~/.bash_profile; then
+    [ -z "${added_newline}" ] && echo '' >> ~/.bash_profile
+    echo ${executable_source_string} >> ~/.bash_profile
+fi
+
 echo "yvm successfully installed in ${YVM_DIR} with the 'yvm' command aliased as ${executable_alias_path}"


### PR DESCRIPTION
## Description
<!-- Add a bulleted list of items changed or added -->

- Add line to source yvm in `.bash_profile


## DevQA

### DevQA Prep
<!-- Delete items that do not apply. -->
- Open bash
- Start fresh:
	- `rm /usr/local/bin/yvm`
	- `rm -rf ~/.yvm`
	- Remove yvm versions from PATH
	- Remove lines that source yvm in `~/.bash_profile` if it exists

### DevQA Steps
<!-- Fill in steps to DevQA this PR here -->
- Run `make install`
- Run `type yvm`
	- Verify that it says `yvm is a function`
- Check that yvm is sourced in `~/.bash_profile`
- Check that you can use `yvm use` correctly
