### PR TITLE
Validate install version is >= 1.0.0

### DIFF
--- a/src/commands/install.js
+++ b/src/commands/install.js
@@ -7,6 +7,7 @@ const log = require('../common/log')
 const {
     versionRootPath,
     getExtractionPath,
+    getVersionsFromTags,
     yvmPath,
 } = require('../common/utils')
 
@@ -81,16 +82,29 @@ const extractYarn = (version, rootPath) => {
 
 const installVersion = (version, rootPath = yvmPath) => {
     if (checkForVersion(version, rootPath)) {
+        log(`It looks like you already have yarn ${version} installed...`)
         return Promise.resolve()
     }
-    return downloadVersion(version, rootPath)
-        .then(() => {
-            log(`Finished downloading yarn version ${version}`)
-            return extractYarn(version, rootPath)
+    return getVersionsFromTags()
+        .then(versions => {
+            if (versions.indexOf(version) === -1) {
+                log(
+                    'You have provided an invalid version number. use "yvm ls-remote" to see valid versions.',
+                )
+                return Promise.resolve()
+            }
+            return downloadVersion(version, rootPath)
+                .then(() => {
+                    log(`Finished downloading yarn version ${version}`)
+                    return extractYarn(version, rootPath)
+                })
+                .catch(err => {
+                    log(`Downloading yarn failed: \n ${err}`)
+                    cleanDirectories()
+                })
         })
-        .catch(err => {
-            log(`Downloading yarn failed: \n ${err}`)
-            cleanDirectories()
+        .catch(error => {
+            log(error)
         })
 }
 

--- a/src/commands/listRemote.js
+++ b/src/commands/listRemote.js
@@ -1,32 +1,16 @@
-const request = require('request')
-
 const log = require('../common/log')
-const { printVersions, stripVersionPrefix } = require('../common/utils')
+const { getVersionsFromTags, printVersions } = require('../common/utils')
 
 const listRemoteCommand = () => {
     log('list-remote')
-    const options = {
-        url: 'https://api.github.com/repos/yarnpkg/yarn/tags',
-        headers: {
-            'User-Agent': 'YVM',
-        },
-    }
 
-    request.get(options, (error, response, body) => {
-        if (error || response.statusCode !== 200) {
-            log(
-                'Unable to fetch available Yarn versions.',
-                'Please check network connection.',
-            )
-            process.exit(1)
-        }
-
-        const tags = JSON.parse(body)
-        const tagNames = tags.map(tag => tag.name)
-        const versions = tagNames.map(stripVersionPrefix)
-
-        printVersions(versions, 'Versions available for install:')
-    })
+    return getVersionsFromTags()
+        .then(versions => {
+            printVersions(versions, 'Versions available for install:')
+        })
+        .catch(error => {
+            log(error)
+        })
 }
 
 module.exports = listRemoteCommand

--- a/src/common/utils.js
+++ b/src/common/utils.js
@@ -35,7 +35,9 @@ const getVersionsFromTags = () => {
             } else {
                 const tags = JSON.parse(body)
                 const tagNames = tags.map(tag => tag.name)
-                const versions = tagNames.map(stripVersionPrefix)
+                const versions = tagNames
+                    .map(stripVersionPrefix)
+                    .filter(version => version[0] > 0)
                 resolve(versions)
             }
         })


### PR DESCRIPTION
## Description
- Moved request for yarn tags to be a util function
- Updated list-remote to use the util function
- Updated install to use the util function to check if the user's version matches what we support
- support for versions greater than 1.0.0

## DevQA

### DevQA Steps
- `make install`
- `yvm install 1.7.0` should work
- `yvm install 1.9.0` should not work
- `yvm install `0.28.4` should not work
- ensure `yvm list-remote` works as expected (displays all valid versions over 1.0.0)
