### PR TITLE
Add `yvm use` to help and warn if user tries to run directly using Node

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -88,15 +88,6 @@ argParser
     })
 
 argParser
-    .command('list-remote')
-    .alias('ls-remote')
-    .description('List Yarn versions available to install.')
-    .action(() => {
-        const listRemote = require('./commands/listRemote')
-        listRemote()
-    })
-
-argParser
     .command('list')
     .alias('ls')
     .description('List the currently installed versions of Yarn.')

--- a/src/index.js
+++ b/src/index.js
@@ -65,6 +65,11 @@ argParser
     }))
 
 argParser
+    .command('use [version]')
+    .description('Activate specified Yarn version, or use .yvmrc if present.')
+    .action(() => log('Do not call yvm.js directly! Instead, run `yvm use`.'))
+
+argParser
     .command('list-remote')
     .alias('ls-remote')
     .description('List Yarn versions available to install.')


### PR DESCRIPTION
## Description

Addresses #60. 

## DevQA

### DevQA Prep
<!-- Delete items that do not apply. -->
- Run `make install`

### DevQA Steps
<!-- Fill in steps to DevQA this PR here -->

- Run `yvm help`
	- Verify that `use` command is listed with message
- Run `node ~/.yvm/yvm.js use`
	- Verify that user is warned that they shouldn't call the JS file directly

