### PR TITLE
Remove 'v' prefix from versions in `yvm list`

### DIFF
--- a/src/commands/list.js
+++ b/src/commands/list.js
@@ -1,7 +1,12 @@
 const fs = require('fs')
 
 const log = require('../common/log')
-const { printVersions, versionRootPath, yvmPath } = require('../common/utils')
+const {
+    printVersions,
+    stripVersionPrefix,
+    versionRootPath,
+    yvmPath,
+} = require('../common/utils')
 
 const getYarnVersions = rootPath => {
     const re = /^v(\d+\.)(\d+\.)(\d+)$/
@@ -9,6 +14,7 @@ const getYarnVersions = rootPath => {
         return fs
             .readdirSync(versionRootPath(rootPath))
             .filter(file => re.test(file))
+            .map(stripVersionPrefix)
     }
     return []
 }


### PR DESCRIPTION
## Description
<!-- Add a bulleted list of items changed or added -->

Addresses #72 

## DevQA

### DevQA Prep
<!-- Delete items that do not apply. -->
- Please `make install`

### DevQA Steps
<!-- Fill in steps to DevQA this PR here -->

- Run `yvm list` and then `yvm list-remote`
	- Verify that version formatting matches



