### PR TITLE
Update `make install-watch` and `install.sh` to clean up symlinks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
       - checkout
       - *restore_cache
       - *install_yvm
-      - run: yvm exec install
+      - run: source ~/.yvm/yvm.sh && yvm exec install
       - *save_cache
       - run: source ~/.yvm/yvm.sh && yvm use && make lint
       - run: source ~/.yvm/yvm.sh && yvm use && make test-coverage

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,8 @@
 version: 2
 
 docker_defaults: &docker_defaults
+  environment:
+    BASH_ENV: ~/.bashrc
   docker:
     - image: circleci/node:8.11.3
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ install_yvm: &install_yvm
   run:
     name: 'Install yvm release version'
     command: |
-      'curl https://raw.githubusercontent.com/tophatmonocle/yvm/master/scripts/install.sh | YVM_ALIAS_DIR=$(pwd) bash'
+      curl https://raw.githubusercontent.com/tophatmonocle/yvm/master/scripts/install.sh | YVM_ALIAS_DIR=$(pwd) bash
       echo 'export PATH=$HOME/.yvm:$PATH' >> $BASH_ENV
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,10 +28,10 @@ jobs:
       - checkout
       - *restore_cache
       - *install_yvm
-      - run: yvm exec install
+      - run: ./home/circleci/.yvm exec install
       - *save_cache
-      - run: nvm use && make lint
-      - run: nvm use && make test-coverage
+      - run: ./home/circleci/.yvm use && make lint
+      - run: ./home/circleci/.yvm use && make test-coverage
       - store_test_results:
           path: artifacts/reports/tests
   build_and_deploy:
@@ -40,7 +40,7 @@ jobs:
       - checkout
       - *restore_cache
       - *install_yvm
-      - run: nvm use && make build_and_deploy
+      - run: ./home/circleci/.yvm use && make build_and_deploy
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,9 +28,11 @@ jobs:
       - checkout
       - *restore_cache
       - *install_yvm
-      - run: ~/.yvm/yvm.sh exec install
+      - run: source ~/.yvm/yvm.sh
+      - run: yvm exec install
       - *save_cache
-      - run: ~/.yvm/yvm.sh use && make lint
+      - run: yvm use
+      - run: make lint
       - run: ~/.yvm/yvm.sh use && make test-coverage
       - store_test_results:
           path: artifacts/reports/tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,7 @@ install_yvm: &install_yvm
       curl https://raw.githubusercontent.com/tophatmonocle/yvm/master/scripts/install.sh | YVM_ALIAS_DIR=$(pwd) bash
       echo 'export PATH=$HOME/.yvm:$PATH' >> $BASH_ENV
       echo 'source ~/.yvm/yvm.sh' >> $BASH_ENV
+      source /home/circleci/.bashrc
 
 jobs:
   test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,12 +28,10 @@ jobs:
       - checkout
       - *restore_cache
       - *install_yvm
-      - run: source ~/.yvm/yvm.sh
       - run: yvm exec install
       - *save_cache
-      - run: yvm use
-      - run: make lint
-      - run: ~/.yvm/yvm.sh use && make test-coverage
+      - run: source ~/.yvm/yvm.sh && yvm use && make lint
+      - run: source ~/.yvm/yvm.sh && yvm use && make test-coverage
       - store_test_results:
           path: artifacts/reports/tests
   build_and_deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,7 @@ install_yvm: &install_yvm
     command: |
       curl https://raw.githubusercontent.com/tophatmonocle/yvm/master/scripts/install.sh | YVM_ALIAS_DIR=$(pwd) bash
       echo 'export PATH=$HOME/.yvm:$PATH' >> $BASH_ENV
+      echo 'source $HOME/.yvm/yvm.sh' >> $BASH_ENV
 
 jobs:
   test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,10 +28,10 @@ jobs:
       - checkout
       - *restore_cache
       - *install_yvm
-      - run: ./home/circleci/.yvm exec install
+      - run: ~/.yvm/yvm.sh exec install
       - *save_cache
-      - run: ./home/circleci/.yvm use && make lint
-      - run: ./home/circleci/.yvm use && make test-coverage
+      - run: ~/.yvm/yvm.sh use && make lint
+      - run: ~/.yvm/yvm.sh use && make test-coverage
       - store_test_results:
           path: artifacts/reports/tests
   build_and_deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ install_yvm: &install_yvm
     command: |
       curl https://raw.githubusercontent.com/tophatmonocle/yvm/master/scripts/install.sh | YVM_ALIAS_DIR=$(pwd) bash
       echo 'export PATH=$HOME/.yvm:$PATH' >> $BASH_ENV
-      echo 'source $HOME/.yvm/yvm.sh' >> $BASH_ENV
+      echo 'source ~/.yvm/yvm.sh' >> $BASH_ENV
 
 jobs:
   test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,19 +28,19 @@ jobs:
       - checkout
       - *restore_cache
       - *install_yvm
-      - run: make lint
-      # CODECOV_TOKEN is set by CIRCLE_CI
-      - run: make test-coverage
+      - run: yvm exec install
+      - *save_cache
+      - run: nvm use && make lint
+      - run: nvm use && make test-coverage
       - store_test_results:
           path: artifacts/reports/tests
-      - *save_cache
   build_and_deploy:
     <<: *docker_defaults
     steps:
       - checkout
       - *restore_cache
       - *install_yvm
-      - run: make build_and_deploy
+      - run: nvm use && make build_and_deploy
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,9 @@ save_cache: &save_cache
 install_yvm: &install_yvm
   run:
     name: 'Install yvm release version'
-    command: 'curl https://raw.githubusercontent.com/tophatmonocle/yvm/master/scripts/install.sh | YVM_ALIAS_DIR=$(pwd) bash'
+    command: |
+      'curl https://raw.githubusercontent.com/tophatmonocle/yvm/master/scripts/install.sh | YVM_ALIAS_DIR=$(pwd) bash'
+      echo 'export PATH=$HOME/.yvm:$PATH' >> $BASH_ENV
 
 jobs:
   test:
@@ -28,10 +30,10 @@ jobs:
       - checkout
       - *restore_cache
       - *install_yvm
-      - run: source ~/.yvm/yvm.sh && yvm exec install
+      - run: yvm exec install
       - *save_cache
-      - run: source ~/.yvm/yvm.sh && yvm use && make lint
-      - run: source ~/.yvm/yvm.sh && yvm use && make test-coverage
+      - run: yvm use && make lint
+      - run: yvm use && make test-coverage
       - store_test_results:
           path: artifacts/reports/tests
   build_and_deploy:
@@ -40,7 +42,7 @@ jobs:
       - checkout
       - *restore_cache
       - *install_yvm
-      - run: ./home/circleci/.yvm use && make build_and_deploy
+      - run: yvm use && make build_and_deploy
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,6 @@ jobs:
       - *restore_cache
       - *install_yvm
       - run: make lint
-      # CODECOV_TOKEN is set by CIRCLE_CI
       - run: make test-coverage
       - store_test_results:
           path: artifacts/reports/tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,6 @@
 version: 2
 
 docker_defaults: &docker_defaults
-  environment:
-    BASH_ENV: ~/.bashrc
   docker:
     - image: circleci/node:8.11.3
 
@@ -21,11 +19,7 @@ save_cache: &save_cache
 install_yvm: &install_yvm
   run:
     name: 'Install yvm release version'
-    command: |
-      curl https://raw.githubusercontent.com/tophatmonocle/yvm/master/scripts/install.sh | YVM_ALIAS_DIR=$(pwd) bash
-      echo 'export PATH=$HOME/.yvm:$PATH' >> $BASH_ENV
-      echo 'source ~/.yvm/yvm.sh' >> $BASH_ENV
-      source /home/circleci/.bashrc
+    command: 'curl https://raw.githubusercontent.com/tophatmonocle/yvm/master/scripts/install.sh | YVM_ALIAS_DIR=$(pwd) bash'
 
 jobs:
   test:
@@ -34,19 +28,19 @@ jobs:
       - checkout
       - *restore_cache
       - *install_yvm
-      - run: yvm exec install
-      - *save_cache
-      - run: yvm use && make lint
-      - run: yvm use && make test-coverage
+      - run: make lint
+      # CODECOV_TOKEN is set by CIRCLE_CI
+      - run: make test-coverage
       - store_test_results:
           path: artifacts/reports/tests
+      - *save_cache
   build_and_deploy:
     <<: *docker_defaults
     steps:
       - checkout
       - *restore_cache
       - *install_yvm
-      - run: yvm use && make build_and_deploy
+      - run: make build_and_deploy
 
 workflows:
   version: 2

--- a/Makefile
+++ b/Makefile
@@ -45,11 +45,7 @@ install: build
 
 .PHONY: install-watch
 install-watch: node_modules
-	mkdir -p ${CURRENT_DIR}/artifacts/webpack_build/
-	rm -rf ~/.yvm
-	ln -s ${CURRENT_DIR}/artifacts/webpack_build/ ${HOME}/.yvm
-	chmod +x ${HOME}/.yvm/yvm.sh
-	webpack --progress --config webpack/webpack.config.dev.js --watch
+	scripts/install-watch.sh
 
 
 # ---- Infrastructure for Test/Deploy ----

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,7 @@
 SHELL := /bin/bash
 CURRENT_DIR = $(shell pwd)
 
-YVM_DIR?=$(HOME)/.yvm
-YVM_EXECUTABLE := $(YVM_DIR)/yvm.sh
-export PATH := $(shell $(YVM_EXECUTABLE) exec bin):$(PATH)
+export PATH := $(shell yarn bin):$(PATH)
 
 ARTIFACT_DIR?=artifacts
 TEST_REPORTS_DIR?=$(ARTIFACT_DIR)/reports
@@ -85,6 +83,7 @@ test: node_modules
 test-watch: node_modules
 	${JEST_ENV_VARIABLES} jest ${JEST_ARGS} --watch
 
+# CODECOV_TOKEN is set by CIRCLE_CI
 .PHONY: test-coverage
 test-coverage: node_modules
 	${JEST_ENV_VARIABLES} jest ${JEST_ARGS} --coverage
@@ -99,7 +98,7 @@ test-snapshots: node_modules
 
 .PHONY: node_modules
 node_modules:
-	$(YVM_EXECUTABLE) exec install
+	yarn install
 	touch node_modules
 
 .PHONY: clean

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 SHELL := /bin/bash
 CURRENT_DIR = $(shell pwd)
 
-export PATH := $(shell yarn bin):$(PATH)
+YVM_DIR?=$(HOME)/.yvm
+YVM_EXECUTABLE := $(YVM_DIR)/yvm.sh
+export PATH := $(shell $(YVM_EXECUTABLE) exec bin):$(PATH)
 
 ARTIFACT_DIR?=artifacts
 TEST_REPORTS_DIR?=$(ARTIFACT_DIR)/reports
@@ -40,6 +42,7 @@ help:
 .PHONY: install
 install: build
 	@use_local=true scripts/install.sh
+
 
 .PHONY: install-watch
 install-watch: node_modules
@@ -98,7 +101,7 @@ test-snapshots: node_modules
 
 .PHONY: node_modules
 node_modules:
-	yarn install
+	$(YVM_EXECUTABLE) exec install
 	touch node_modules
 
 .PHONY: clean

--- a/scripts/install-watch.sh
+++ b/scripts/install-watch.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+CURRENT_DIR=$(pwd)
+
+# Need to delete files, otherwise links are not created
+rm ${HOME}/.yvm/yvm.sh
+rm ${HOME}/.yvm/yvm.js
+
+# Link
+ln -s ${CURRENT_DIR}/artifacts/webpack_build/yvm.sh ${HOME}/.yvm/yvm.sh
+ln -s ${CURRENT_DIR}/artifacts/webpack_build/yvm.js ${HOME}/.yvm/yvm.js
+chmod +x ${HOME}/.yvm/yvm.sh
+
+# Start Webpack in watch mode
+webpack --progress --config webpack/webpack.config.dev.js --watch

--- a/scripts/install-watch.sh
+++ b/scripts/install-watch.sh
@@ -2,14 +2,48 @@
 
 CURRENT_DIR=$(pwd)
 
-# Need to delete files, otherwise links are not created
-rm ${HOME}/.yvm/yvm.sh
-rm ${HOME}/.yvm/yvm.js
+# Check if already watching
+if test -L "${HOME}/.yvm/yvm.sh" || test -L "${HOME}/.yvm/yvm.js"
+then
+    echo "Unable to save existing files!"
+    echo "Make sure you do not have install-watch already running."
+    exit 1
+fi
+
+# Save existing files
+echo "Saving yvm.sh and yvm.js"
+mv "${HOME}/.yvm/yvm.sh" "${HOME}/.yvm/yvm_save.sh"
+mv "${HOME}/.yvm/yvm.js" "${HOME}/.yvm/yvm_save.js"
 
 # Link
-ln -s ${CURRENT_DIR}/artifacts/webpack_build/yvm.sh ${HOME}/.yvm/yvm.sh
-ln -s ${CURRENT_DIR}/artifacts/webpack_build/yvm.js ${HOME}/.yvm/yvm.js
-chmod +x ${HOME}/.yvm/yvm.sh
+ln -s ${CURRENT_DIR}/artifacts/webpack_build/yvm.sh "${HOME}/.yvm/yvm.sh"
+ln -s ${CURRENT_DIR}/artifacts/webpack_build/yvm.js "${HOME}/.yvm/yvm.js"
+chmod +x "${HOME}/.yvm/yvm.sh"
+
+# Trap interrupt signal
+int_trap() {
+    echo "Stopped Webpack"
+}
+trap int_trap INT
 
 # Start Webpack in watch mode
 webpack --progress --config webpack/webpack.config.dev.js --watch
+
+# Clean up
+echo "Cleaning up"
+
+rm "${HOME}/.yvm/yvm.sh"
+rm "${HOME}/.yvm/yvm.js"
+
+# Try to recover
+if [ -f "${HOME}/.yvm/yvm_save.sh" ]
+then
+    mv "${HOME}/.yvm/yvm_save.sh" "${HOME}/.yvm/yvm.sh"
+    echo "Restored yvm.sh"
+fi
+
+if [ -f "${HOME}/.yvm/yvm_save.js" ]
+then
+    mv "${HOME}/.yvm/yvm_save.js" "${HOME}/.yvm/yvm.js"
+    echo "Restored yvm.js"
+fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -27,7 +27,8 @@ mkdir -p ${YVM_DIR}
 mkdir -p ${YVM_ALIAS_DIR}
 
 if [ "$use_local" = true ]; then
-    cp -f "${artifacts_dir}/yvm.sh" "${artifacts_dir}/yvm.js" ${YVM_DIR}
+    rm -f "${YVM_DIR}/yvm.sh" "${YVM_DIR}/yvm.js"
+    cp "${artifacts_dir}/yvm.sh" "${artifacts_dir}/yvm.js" ${YVM_DIR}
 else
     download_url=$(
         curl -s ${release_api_url} |

--- a/yarn.lock
+++ b/yarn.lock
@@ -2630,7 +2630,7 @@ glob-parent@^3.1.0:
     is-glob "^3.1.0"
     path-dirname "^1.0.0"
 
-glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2:
+glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
   dependencies:
@@ -2969,7 +2969,7 @@ inquirer@^6.0.0:
     strip-ansi "^4.0.0"
     through "^2.3.6"
 
-interpret@^1.1.0:
+interpret@^1.0.0, interpret@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.1.0.tgz#7ed1b1410c6a0e0f78cf95d3b8440c63f78b8614"
 
@@ -4922,6 +4922,12 @@ realpath-native@^1.0.0:
   dependencies:
     util.promisify "^1.0.0"
 
+rechoir@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.6.2.tgz#85204b54dba82d5742e28c96756ef43af50e3384"
+  dependencies:
+    resolve "^1.1.6"
+
 regenerate-unicode-properties@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/regenerate-unicode-properties/-/regenerate-unicode-properties-7.0.0.tgz#107405afcc4a190ec5ed450ecaa00ed0cafa7a4c"
@@ -5091,7 +5097,7 @@ resolve@1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
 
-resolve@^1.3.2, resolve@^1.5.0, resolve@^1.6.0:
+resolve@^1.1.6, resolve@^1.3.2, resolve@^1.5.0, resolve@^1.6.0:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.8.1.tgz#82f1ec19a423ac1fbd080b0bab06ba36e84a7a26"
   dependencies:
@@ -5278,6 +5284,14 @@ shebang-regex@^1.0.0:
 shelljs@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.3.0.tgz#3596e6307a781544f591f37da618360f31db57b1"
+
+shelljs@^0.8.2:
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.2.tgz#345b7df7763f4c2340d584abb532c5f752ca9e35"
+  dependencies:
+    glob "^7.0.0"
+    interpret "^1.0.0"
+    rechoir "^0.6.2"
 
 shellwords@^0.1.1:
   version "0.1.1"


### PR DESCRIPTION
## Description

- Rather than link the entire `artifacts/webpack_build` folder to `~/.yvm`, I decided to link the files that are actually changing (ie. `yvm.js` and `yvm.sh`). 
- Reasoning behind this that subsequent install commands will install into `artifacts/webpack_build` and removing the link will remove the versions you installed.

## DevQA

### DevQA Steps
<!-- Fill in steps to DevQA this PR here -->

- Run `make install-watch`
	- Verify that changes to code are updated without having to re-run install
- Stop watcher, run `make install`
	- Verify that links are removed, and normal install is completed
