### PR TITLE
Add support for search up directories for .yvmrc (as well as looking in package.json etc)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,6 @@
 1. Ensure the problem you are solving [is an issue](https://github.com/tophatmonocle/yvm/issues) or you've created one
 1. Clone the repo
 1. We use make, `make help` will show you a list of development commands
-1. `yarn install`
 1. `make install-watch` will install yvm on your shell, and update when you make changes
 1. `make test` and `make lint` are also commonly helpful
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ yvm help
 
 ### Using a .yvmrc File
 You can create a `.yvmrc` file containing the version number of yarn in your project's root directory. Afterwards, `yvm use`, `yvm install` and `yvm exec` will use the version specified in the `.yvmrc` file if no version number is supplied to the command.
-
+You can also [declare the version using other configuration files](docs/faq.md)
 
 ### Additional reference
 A full list of commands is on the [api reference page](docs/api.md)

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Thanks goes to these wonderful people [emoji key](https://github.com/kentcdodds/
 | :---: | :---: | :---: | :---: | :---: |
 
 
-We welcome contributions from the community, Top Hatters and non-Top Hatters alike. Check out our [contributing guidelines](docs/contributing.md) for more details.
+We welcome contributions from the community, Top Hatters and non-Top Hatters alike. Check out our [contributing guidelines](CONTRIBUTING.md) for more details.
 
 ## Copyright
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -12,3 +12,8 @@ description: Common questions and answers
 This means you're running the yvm.js script directly and not the shell function.
 Try opening another terminal window, or type `source /usr/local/bin/yvm`
 
+
+## Declare yvm version in a confugration file. Where can I place my version number?
+In `package.json` under the key `yvm` set it to your version number.
+In any file using the correct format: `.yvmrc`, `.yvmrc.json`, `.yvmrc.yaml`, `.yvmrc.yml`, `.yvmrc.js`, `yvm.config.js`
+The files will be searched in the current directory, and then up the tree.

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "license": "ISC",
   "dependencies": {
     "commander": "^2.15.1",
+    "cosmiconfig": "^5.0.5",
     "fs-extra": "^6.0.1",
     "gh-release": "^3.2.1",
     "request": "^2.87.0",

--- a/scripts/install-watch.sh
+++ b/scripts/install-watch.sh
@@ -27,7 +27,7 @@ int_trap() {
 trap int_trap INT
 
 # Start Webpack in watch mode
-webpack --progress --config webpack/webpack.config.dev.js --watch
+./node_modules/.bin/webpack --progress --config webpack/webpack.config.dev.js --watch
 
 # Clean up
 echo "Cleaning up"

--- a/src/util/version.js
+++ b/src/util/version.js
@@ -1,19 +1,18 @@
-const fs = require('fs')
+const cosmiconfig = require('cosmiconfig')
+const log = require('../common/log')
 
 function isValidVersionString(version) {
     return /\d+\.\d+\.\d+/.test(version)
 }
 
 function getRcFileVersion() {
-    try {
-        const rcFileContents = fs.readFileSync('.yvmrc', 'utf-8')
-        return rcFileContents.replace('\n', '')
-    } catch (e) {
-        if (e.code === 'ENOENT') {
-            return null
-        }
-        throw e
+    const explorer = cosmiconfig('yvm')
+    const result = explorer.searchSync()
+    if (!result || result.isEmpty || !result.config) {
+        return null
     }
+    log(`Found config ${result.filepath}`)
+    return result.config
 }
 
 module.exports = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1654,7 +1654,7 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
-cosmiconfig@^5.0.2:
+cosmiconfig@^5.0.2, cosmiconfig@^5.0.5:
   version "5.0.5"
   resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.0.5.tgz#a809e3c2306891ce17ab70359dc8bdf661fe2cd0"
   dependencies:


### PR DESCRIPTION
## Description
Fixes: Running `yvm exec` in a nested directory, says it can't find the .yvmrc file #108 



## DevQA
Execute `yvm exec --version` in a directory with a `.yvmrc`, in a directory outside, and in a sub directory. Verify behaviour is correct.

