### PR TITLE
Move PATH editing logic to JS

### DIFF
--- a/src/commands/getNewPath.js
+++ b/src/commands/getNewPath.js
@@ -2,8 +2,12 @@ const path = require('path')
 
 const { versionRootPath, yvmPath } = require('../common/utils')
 
-const getPath = (version, rootPath = yvmPath) => {
-    const splitPath = process.env.PATH.split(path.delimiter)
+const getNewPath = (
+    version,
+    rootPath = yvmPath,
+    pathString = process.env.PATH,
+) => {
+    const splitPath = pathString.split(path.delimiter)
     const destPath = versionRootPath(rootPath)
 
     const newPathSegment = `${destPath}/v${version}/bin`
@@ -25,4 +29,4 @@ const getPath = (version, rootPath = yvmPath) => {
     return splitPath.join(path.delimiter)
 }
 
-module.exports = getPath
+module.exports = getNewPath

--- a/src/commands/getPath.js
+++ b/src/commands/getPath.js
@@ -1,0 +1,28 @@
+const path = require('path')
+
+const { versionRootPath, yvmPath } = require('../common/utils')
+
+const getPath = (version, rootPath = yvmPath) => {
+    const splitPath = process.env.PATH.split(path.delimiter)
+    const destPath = versionRootPath(rootPath)
+
+    const newPathSegment = `${destPath}/v${version}/bin`
+    let hadExistingPath = false
+
+    for (let i = 0; i < splitPath.length; i += 1) {
+        const pathSegment = splitPath[i]
+        if (pathSegment.startsWith(destPath)) {
+            splitPath[i] = newPathSegment
+            hadExistingPath = true
+            break
+        }
+    }
+
+    if (!hadExistingPath) {
+        splitPath.unshift(newPathSegment)
+    }
+
+    return splitPath.join(path.delimiter)
+}
+
+module.exports = getPath

--- a/src/yvm.js
+++ b/src/yvm.js
@@ -102,8 +102,13 @@ argParser
     .command('get-path [version]')
     .description('Activate specified Yarn version, or use .yvmrc if present.')
     .action(version => {
-        const getPath = require('./commands/getPath')
-        log.capturable(getPath(version))
+        if (!version) {
+            log('Version missing')
+        } else {
+            const getPath = require('./commands/getPath')
+            log.capturable(getPath(version))
+            log(`Set yarn version to ${version}`)
+        }
     })
 
 argParser

--- a/src/yvm.js
+++ b/src/yvm.js
@@ -100,14 +100,13 @@ argParser
 
 argParser
     .command('get-path [version]')
-    .description('Activate specified Yarn version, or use .yvmrc if present.')
+    .description('Internal command: Gets a new PATH string for "yvm use"')
     .action(version => {
         if (!version) {
             log('Version missing')
         } else {
             const getPath = require('./commands/getPath')
             log.capturable(getPath(version))
-            log(`Set yarn version to ${version}`)
         }
     })
 

--- a/src/yvm.js
+++ b/src/yvm.js
@@ -105,12 +105,12 @@ argParser
     })
 
 argParser
-    .command('get-path [version]')
+    .command('get-new-path [version]')
     .description('Internal command: Gets a new PATH string for "yvm use"')
     .action(maybeVersion => {
         const [version] = getYarnVersion(maybeVersion)
-        const getPath = require('./commands/getPath')
-        log.capturable(getPath(version))
+        const getNewPath = require('./commands/getNewPath')
+        log.capturable(getNewPath(version))
     })
 
 argParser

--- a/src/yvm.js
+++ b/src/yvm.js
@@ -99,6 +99,14 @@ argParser
     })
 
 argParser
+    .command('get-path [version]')
+    .description('Activate specified Yarn version, or use .yvmrc if present.')
+    .action(version => {
+        const getPath = require('./commands/getPath')
+        log.capturable(getPath(version))
+    })
+
+argParser
     .command('update-self')
     .description('Updates yvm to the latest version')
     .action(() => log('You need to source yvm to use this command. run `source /usr/local/bin/yvm`'))

--- a/src/yvm.js
+++ b/src/yvm.js
@@ -101,14 +101,15 @@ argParser
 argParser
     .command('get-path [version]')
     .description('Internal command: Gets a new PATH string for "yvm use"')
-    .action(version => {
+    .action(withRcFileVersion(version => {
         if (!version) {
             log('Version missing')
+            process.exit(1)
         } else {
             const getPath = require('./commands/getPath')
             log.capturable(getPath(version))
         }
-    })
+    }))
 
 argParser
     .command('update-self')

--- a/src/yvm.js
+++ b/src/yvm.js
@@ -108,6 +108,7 @@ argParser
         } else {
             const getPath = require('./commands/getPath')
             log.capturable(getPath(version))
+            log(`Set yarn version to ${version}`)
         }
     }))
 

--- a/src/yvm.sh
+++ b/src/yvm.sh
@@ -10,7 +10,6 @@ yvm_use() {
         yvm_err "Could not get new path from yvm"
     else
         PATH=${NEW_PATH}
-        yvm_echo "Set yarn version to ${PROVIDED_VERSION}"
     fi
 }
 

--- a/src/yvm.sh
+++ b/src/yvm.sh
@@ -5,7 +5,7 @@ YVM_DIR=${YVM_DIR-"${HOME}/.yvm"}
 
 yvm_use() {
     local PROVIDED_VERSION=${1}
-    NEW_PATH=$(yvm_call_node_script get-path ${PROVIDED_VERSION})
+    NEW_PATH=$(yvm_call_node_script get-new-path ${PROVIDED_VERSION})
     if [ -z "${NEW_PATH}" ]; then
         yvm_err "Could not get new path from yvm"
     else

--- a/src/yvm.sh
+++ b/src/yvm.sh
@@ -5,7 +5,7 @@ YVM_DIR=${YVM_DIR-"${HOME}/.yvm"}
 
 yvm_use() {
     local PROVIDED_VERSION=${1}
-    NEW_PATH=$(yvm get-path ${PROVIDED_VERSION})
+    NEW_PATH=$(yvm_call_node_script get-path ${PROVIDED_VERSION})
     if [ -z "${NEW_PATH}" ]; then
         yvm_err "Could not get new path from yvm"
     else
@@ -19,6 +19,11 @@ yvm_echo() {
 
 yvm_err() {
     >&2 yvm_echo "$@"
+}
+
+yvm_call_node_script() {
+    # do not add anything that outputs stuff to stdout in function, its output is stored in a variable
+    node "${YVM_DIR}/yvm.js" $@
 }
 
 case "$-" in
@@ -40,7 +45,7 @@ yvm_() {
     elif [ "${command}" = "update-self" ]; then
         curl https://raw.githubusercontent.com/tophatmonocle/yvm/master/scripts/install.sh | YVM_INSTALL_DIR=${YVM_DIR} bash
     else
-        node "${YVM_DIR}/yvm.js" $@
+        yvm_call_node_script $@
     fi
 }
 

--- a/src/yvm.sh
+++ b/src/yvm.sh
@@ -5,34 +5,8 @@ YVM_DIR=${YVM_DIR-"${HOME}/.yvm"}
 
 yvm_use() {
     local PROVIDED_VERSION=${1-$(head -n 1 .yvmrc)}
-
-    if [ -z "${PROVIDED_VERSION}" ]; then
-        yvm_err 'version is required'
-        return 3
-    fi
-
-    if ! yvm_is_version_installed "$PROVIDED_VERSION"; then
-        yvm_ 'function' install ${PROVIDED_VERSION}
-    fi
-
-    local YVM_VERSION_DIR
-    YVM_VERSION_DIR="$(yvm_version_path "$PROVIDED_VERSION")"
-    PATH="$(yvm_change_path "$PATH" "/bin" "$YVM_VERSION_DIR")"
+    PATH=$(yvm get-path ${PROVIDED_VERSION})
     echo "Set yarn version to ${PROVIDED_VERSION}"
-}
-
-yvm_is_version_installed() {
-    [ -n "${1-}" ] && [ -x "$(yvm_version_path "$1" 2> /dev/null)"/bin/yarn ]
-}
-
-yvm_version_path() {
-    local VERSION
-    VERSION="${1-}"
-    if [ -z "${VERSION}" ]; then
-        yvm_err 'version is required'
-        return 3
-    else yvm_echo "$(yvm_version_dir)/v${VERSION}"
-    fi
 }
 
 yvm_echo() {
@@ -41,37 +15,6 @@ yvm_echo() {
 
 yvm_err() {
     >&2 yvm_echo "$@"
-}
-
-yvm_version_dir() {
-    local YVM_WHICH_DIR
-    YVM_WHICH_DIR="${1-}"
-    if [ -z "${YVM_WHICH_DIR}" ]; then
-        yvm_echo "${YVM_DIR}/versions"
-    else
-        yvm_err 'unknown version dir'
-        return 3
-    fi
-}
-
-yvm_grep() {
-    GREP_OPTIONS='' command grep "$@"
-}
-
-yvm_change_path() {
-    # if there’s no initial path, just return the supplementary path
-    if [ -z "${1-}" ]; then
-        yvm_echo "${3-}${2-}"
-    # if the initial path doesn’t contain an yvm path, prepend the supplementary
-    # path
-elif ! yvm_echo "${1-}" | yvm_grep -q "${YVM_DIR}/versions/[^/]*${2-}"; then
-    yvm_echo "${3-}${2-}:${1-}"
-    # use sed to replace the existing yvm path with the supplementary path. This
-    # preserves the order of the path.
-else
-    yvm_echo "${1-}" | command sed \
-    -e "s#${YVM_DIR}/versions/[^/]*${2-}[^:]*#${3-}${2-}#"
-fi
 }
 
 case "$-" in

--- a/src/yvm.sh
+++ b/src/yvm.sh
@@ -10,6 +10,7 @@ yvm_use() {
         yvm_err "Could not get new path from yvm"
     else
         PATH=${NEW_PATH}
+        yvm_echo "Set yarn version to ${PROVIDED_VERSION}"
     fi
 }
 

--- a/src/yvm.sh
+++ b/src/yvm.sh
@@ -4,9 +4,13 @@ command=$1
 YVM_DIR=${YVM_DIR-"${HOME}/.yvm"}
 
 yvm_use() {
-    local PROVIDED_VERSION=${1-$(head -n 1 .yvmrc)}
-    PATH=$(yvm get-path ${PROVIDED_VERSION})
-    echo "Set yarn version to ${PROVIDED_VERSION}"
+    local PROVIDED_VERSION=${1}
+    NEW_PATH=$(yvm get-path ${PROVIDED_VERSION})
+    if [ -z "${NEW_PATH}" ]; then
+        yvm_err "Could not get new path from yvm"
+    else
+        PATH=${NEW_PATH}
+    fi
 }
 
 yvm_echo() {

--- a/test/commands/getNewPath.test.js
+++ b/test/commands/getNewPath.test.js
@@ -1,0 +1,40 @@
+const path = require('path')
+
+const getNewPath = require('../../src/commands/getNewPath')
+
+describe('getNewPath', () => {
+    it('Returns a new PATH string with a yarn directory prepended', () => {
+        const mockVersion = '1.7.0'
+        const mockRootPath = '/some/path'
+        const mockSplitPath = ['abc', 'def']
+        const mockPathString = mockSplitPath.join(path.delimiter)
+
+        const expectedPathString = [
+            `${mockRootPath}/versions/v${mockVersion}/bin`,
+            ...mockSplitPath,
+        ].join(path.delimiter)
+        expect(getNewPath(mockVersion, mockRootPath, mockPathString)).toEqual(
+            expectedPathString,
+        )
+    })
+
+    it('Returns a new PATH string with they yarn dir edited if it was already present', () => {
+        const mockVersion = '1.7.0'
+        const mockRootPath = '/some/path'
+        const mockSplitPath = [
+            'abc',
+            `${mockRootPath}/versions/v1.6.0/bin`,
+            'def',
+        ]
+        const mockPathString = mockSplitPath.join(path.delimiter)
+
+        const expectedPathString = [
+            'abc',
+            `${mockRootPath}/versions/v${mockVersion}/bin`,
+            'def',
+        ].join(path.delimiter)
+        expect(getNewPath(mockVersion, mockRootPath, mockPathString)).toEqual(
+            expectedPathString,
+        )
+    })
+})


### PR DESCRIPTION
## Description
<!-- Add a bulleted list of items changed or added -->
- Changes `yvm use` to use `yvm get-new-path` under the hood, moving most of the logic into JS for consistency
- Closes #112


## DevQA

### DevQA Steps
- `make install-watch`
- Open a new shell
- `yvm use` should still work
- `yvm get-new-path 1.7.0` should return a PATH string for yarn 1.7.0
- `yvm get-new-path` should use the version in .yvmrc
- `yvm use 1.6.0` then `yvm get-new-path 1.7.0` should edit the existing PATH string, not prepend a new segment to it