### PR TITLE
Silence standard log with YVM_VERBOSE

### DIFF
--- a/src/commands/install.js
+++ b/src/commands/install.js
@@ -81,7 +81,6 @@ const extractYarn = (version, rootPath) => {
 }
 
 const installVersion = (version, rootPath = yvmPath) => {
-    log(`Installing yarn v${version} in ${rootPath}`)
     if (checkForVersion(version, rootPath)) {
         log(`It looks like you already have yarn ${version} installed...`)
         return Promise.resolve()
@@ -94,6 +93,7 @@ const installVersion = (version, rootPath = yvmPath) => {
                 )
                 return Promise.reject()
             }
+            log(`Installing yarn v${version} in ${rootPath}`)
             return downloadVersion(version, rootPath)
                 .then(() => {
                     log(`Finished downloading yarn version ${version}`)

--- a/src/commands/listRemote.js
+++ b/src/commands/listRemote.js
@@ -2,7 +2,7 @@ const log = require('../common/log')
 const { getVersionsFromTags, printVersions } = require('../common/utils')
 
 const listRemoteCommand = () => {
-    log('list-remote')
+    log.info('list-remote')
 
     return getVersionsFromTags()
         .then(versions => {

--- a/src/commands/which.js
+++ b/src/commands/which.js
@@ -20,7 +20,9 @@ const whichCommand = inputPath => {
         if (element.startsWith(versionRootPath(yvmPath))) {
             const versionRegex = /(v\d+\.?\d*\.?\d*)/gm
             const matchedVersion = element.match(versionRegex)
-            log(`matched yvm version: ${matchedVersion} in PATH ${element}`)
+            log.info(
+                `matched yvm version: ${matchedVersion} in PATH ${element}`,
+            )
 
             const pathVersion = matchedVersion.toString().replace(/v/g, '')
             const rcVersion = getRcFileVersion()

--- a/src/common/log.js
+++ b/src/common/log.js
@@ -9,4 +9,10 @@ log.capturable = function capturableLog(...args) {
     capturableLogger(...args)
 }
 
+log.info = function errorLog(...args) {
+    if (process.env.YVM_VERBOSE) {
+        log(...args)
+    }
+}
+
 module.exports = log

--- a/src/util/version.js
+++ b/src/util/version.js
@@ -11,7 +11,7 @@ function getRcFileVersion() {
     if (!result || result.isEmpty || !result.config) {
         return null
     }
-    log(`Found config ${result.filepath}`)
+    log.info(`Found config ${result.filepath}`)
     return result.config
 }
 

--- a/src/yvm-exec.js
+++ b/src/yvm-exec.js
@@ -24,14 +24,14 @@ const execFile =
 const runYarn = (version, extraArgs, rootPath) => {
     // first two arguments are filler args [node version, yarn version]
     process.argv = ['', ''].concat(extraArgs)
-    log(`yarn ${extraArgs.join(' ')}`)
+    log.info(`yarn ${extraArgs.join(' ')}`)
     execFile(path.resolve(getYarnPath(version, rootPath), 'bin/yarn.js'))
 }
 
 const execCommand = (version, extraArgs = ['-v'], rootPath = yvmPath) =>
     new Promise(resolve => {
         validateVersionString(version)
-        log(`Using yarn version: ${version}`)
+        log.info(`Using yarn version: ${version}`)
         const yarnBinDir = getYarnPath(version, rootPath)
 
         if (!fs.existsSync(yarnBinDir)) {

--- a/src/yvm.js
+++ b/src/yvm.js
@@ -10,7 +10,7 @@ const log = require('./common/log')
 const withRcFileVersion = action => (maybeVersionArg, ...rest) => {
     if (maybeVersionArg) {
         if (isValidVersionString(maybeVersionArg)) {
-            log(`Using provided version: ${maybeVersionArg}`)
+            log.info(`Using provided version: ${maybeVersionArg}`)
             action(maybeVersionArg, ...rest)
             return
         }
@@ -21,7 +21,7 @@ const withRcFileVersion = action => (maybeVersionArg, ...rest) => {
     try {
         const version = getRcFileVersion()
         validateVersionString(version)
-        log(`Using yarn version: ${version}`)
+        log.info(`Using yarn version: ${version}`)
         action(version, ...rest)
     } catch (e) {
         log(e.message)
@@ -57,7 +57,7 @@ argParser
     .alias('rm')
     .description('Uninstall the specified version of Yarn.')
     .action(version => {
-        log(`Removing yarn v${version}`)
+        log.info(`Removing yarn v${version}`)
         const remove = require('./commands/remove')
         process.exit(remove(version))
     })
@@ -74,7 +74,7 @@ argParser
     .command('which')
     .description('Display path to installed yarn version. Uses .yvmrc if available.')
     .action(() => {
-        log(`Checking yarn version`)
+        log.info(`Checking yarn version`)
         const which = require('./commands/which')
         process.exit(which())
 })
@@ -93,7 +93,7 @@ argParser
     .alias('ls')
     .description('List the currently installed versions of Yarn.')
     .action(() => {
-        log(`Checking for installed yarn versions...`)
+        log.info(`Checking for installed yarn versions...`)
         const listVersions = require('./commands/list')
         listVersions()
     })


### PR DESCRIPTION
## Description
<!-- Add a bulleted list of items changed or added -->
- Info logging that's not relevant to the end user is now hidden behind the `YVM_VERBOSE` env var


## DevQA

### DevQA Steps
- `yvm exec 1.7.0 --version` should just print `1.7.0`
- `YVM_VERBOSE=1 yvm exec 1.7.0 --version` should print 
```
Using yarn version: 1.7.0
yarn --version
1.7.0
```